### PR TITLE
do not throw error if tag not found

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -6158,7 +6158,7 @@ let findPackageVersionByTag = async function (octokit, owner, name, tag) {
     }
   }
 
-  throw new Error(
+  console.warn(
     `package with tag '${tag}' does not exits, available tags: ${Array.from(
       tags
     ).join(", ")}`

--- a/utils.js
+++ b/utils.js
@@ -62,7 +62,7 @@ let findPackageVersionByTag = async function (octokit, owner, name, tag) {
     }
   }
 
-  throw new Error(
+  console.warn(
     `package with tag '${tag}' does not exits, available tags: ${Array.from(
       tags
     ).join(", ")}`

--- a/utils.test.js
+++ b/utils.test.js
@@ -118,16 +118,16 @@ describe("findPackageVersionByTag", () => {
     expect(packageVersion.id).toBe(266441);
   }, 15000);
 
-  test("not existing version throw error", () => {
-    return expect(
-      utils.findPackageVersionByTag(
-        octokit,
-        "bots-house",
-        "docker-telegram-bot-api",
-        "test"
-      )
-    ).rejects.toThrow(new RegExp("package with tag"));
-  });
+//  test("not existing version throw error", () => {
+//    return expect(
+//      utils.findPackageVersionByTag(
+//        octokit,
+//        "bots-house",
+//        "docker-telegram-bot-api",
+//        "test"
+//      )
+//    ).rejects.toThrow(new RegExp("package with tag"));
+//  });
 });
 
 describe("findPackageVersionsUntaggedOrderGreaterThan", () => {


### PR DESCRIPTION
The job there was failing because of missing tags : https://github.com/avnet-embedded/simplecore-tools/actions/runs/10786741887?pr=973
A Warning should be better. Why failed in case of error ?